### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@
 -----------------------
 
 [![Documentation Status](https://readthedocs.org/projects/renderthreads/badge/?version=latest)](https://readthedocs.org/projects/renderthreads/?badge=latest)
-[![Downloads](https://pypip.in/download/renderthreads/badge.svg?style=flat)](https://pypi.python.org/pypi/renderthreads/)
-[![Latest Version](https://pypip.in/version/renderthreads/badge.svg?style=flat)](https://pypi.python.org/pypi/renderthreads/)
-[![Development Status](https://pypip.in/status/renderthreads/badge.svg?style=flat)](https://pypi.python.org/pypi/renderthreads/)
-[![Download format](https://pypip.in/format/renderthreads/badge.svg?style=flat)](https://pypi.python.org/pypi/renderthreads/)
-[![License](https://pypip.in/license/renderthreads/badge.svg?style=flat)](https://pypi.python.org/pypi/renderthreads/)
+[![Downloads](https://img.shields.io/pypi/dm/renderthreads.svg?style=flat)](https://pypi.python.org/pypi/renderthreads/)
+[![Latest Version](https://img.shields.io/pypi/v/renderthreads.svg?style=flat)](https://pypi.python.org/pypi/renderthreads/)
+[![Development Status](https://img.shields.io/pypi/status/renderthreads.svg?style=flat)](https://pypi.python.org/pypi/renderthreads/)
+[![Download format](https://img.shields.io/pypi/format/renderthreads.svg?style=flat)](https://pypi.python.org/pypi/renderthreads/)
+[![License](https://img.shields.io/pypi/l/renderthreads.svg?style=flat)](https://pypi.python.org/pypi/renderthreads/)
 [![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/timmwagener/renderthreads)
 
 -----------------------


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20renderthreads))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `renderthreads`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.